### PR TITLE
fix(workspace): only prompt duck password when required

### DIFF
--- a/runninghub-nextjs/docs/duck-password-prompt-fix-plan.md
+++ b/runninghub-nextjs/docs/duck-password-prompt-fix-plan.md
@@ -1,0 +1,23 @@
+## Overview
+Fix duck image decode UX so password dialog is not shown by default.
+
+## Current State
+- Decode actions treat unknown password state as password-required.
+- `duckRequiresPassword !== false` causes dialog to open even when no password is needed.
+
+## Target State
+- Password dialog opens only when `duckRequiresPassword === true`.
+- If password requirement is `false` or unknown, decode runs directly without prompting.
+
+## Scope
+- `runninghub-nextjs/src/components/workspace/MediaSelectionToolbar.tsx`
+- `runninghub-nextjs/src/components/workspace/MediaGallery.tsx`
+
+## Out of Scope
+- Duck validation API behavior.
+- Duck decoding backend/CLI flow.
+
+## Implementation Phases
+1. Replace prompt gating checks with explicit `=== true` logic.
+2. Ensure direct decode path uses empty password by default.
+3. Validate build and verify no TypeScript regressions.

--- a/runninghub-nextjs/docs/duck-password-prompt-fix-todos.md
+++ b/runninghub-nextjs/docs/duck-password-prompt-fix-todos.md
@@ -1,0 +1,7 @@
+- [x] Add plan for duck password prompt default behavior fix.
+- [x] Update decode prompt gating in media selection toolbar.
+- [x] Update decode prompt gating in media gallery menu.
+- [x] Ensure direct decode path uses empty password when prompt is skipped.
+- [x] Run `npm run build` in `runninghub-nextjs`.
+- [x] Manual UI check: duck image without password decodes without showing dialog.
+- [x] Manual UI check: password-protected duck image still shows password dialog.

--- a/runninghub-nextjs/src/components/workspace/MediaGallery.tsx
+++ b/runninghub-nextjs/src/components/workspace/MediaGallery.tsx
@@ -507,12 +507,17 @@ export function MediaGallery({
 		setDecodePassword("");
 	}, []);
 
-	const handleDecodeConfirm = async (file?: MediaFile) => {
+	const handleDecodeConfirm = async (
+		file?: MediaFile,
+		passwordOverride?: string,
+	) => {
 		const targetFile = file || decodeDialogFile;
 		if (!targetFile || !onDecode) return;
 		try {
 			setIsDecoding(true);
-			await onDecode(targetFile, decodePassword || undefined);
+			const passwordToUse =
+				passwordOverride !== undefined ? passwordOverride : decodePassword;
+			await onDecode(targetFile, passwordToUse || undefined);
 			setDecodeDialogFile(null);
 			setDecodePassword("");
 		} catch (error) {
@@ -1109,10 +1114,10 @@ export function MediaGallery({
 															<DropdownMenuItem
 																onClick={(e) => {
 																	e.stopPropagation();
-										if (file.duckRequiresPassword !== false) {
+																	if (file.duckRequiresPassword === true) {
 																		setDecodeDialogOpen(file);
 																	} else {
-																		handleDecodeConfirm(file);
+																		handleDecodeConfirm(file, "");
 																	}
 																}}
 																className="text-green-600 bg-green-50/50 focus:bg-green-100"

--- a/runninghub-nextjs/src/components/workspace/MediaSelectionToolbar.tsx
+++ b/runninghub-nextjs/src/components/workspace/MediaSelectionToolbar.tsx
@@ -326,12 +326,14 @@ export function MediaSelectionToolbar({
 	}, [onDelete, selectedFiles, onDeselectAll]);
 
 	// Handle decode (single or batch)
-	const handleDecode = useCallback(async () => {
+	const handleDecode = useCallback(async (passwordOverride?: string) => {
 		if (!onDecode || duckEncodedCount === 0) return;
 
 		setIsDecoding(true);
 		setShowDecodeDialog(false); // Close dialog immediately
 		setDecodeProgress({ current: 0, total: duckEncodedCount });
+		const passwordToUse =
+			passwordOverride !== undefined ? passwordOverride : decodePassword;
 
 		try {
 			// Filter duck-encoded images
@@ -341,7 +343,7 @@ export function MediaSelectionToolbar({
 
 			// Decode each file with progress tracking
 			for (let i = 0; i < duckEncodedFiles.length; i++) {
-				await onDecode(duckEncodedFiles[i], decodePassword, {
+				await onDecode(duckEncodedFiles[i], passwordToUse, {
 					current: i + 1,
 					total: duckEncodedFiles.length,
 				});
@@ -760,15 +762,17 @@ export function MediaSelectionToolbar({
 											size="icon"
 											onClick={() => {
 												// Check if any duck-encoded file requires password
-									const requiresPassword = selectedFiles
-										.filter((f) => f.type === "image" && f.isDuckEncoded)
-										.some((f) => f.duckRequiresPassword !== false);
+												const requiresPassword = selectedFiles
+													.filter(
+														(f) => f.type === "image" && f.isDuckEncoded,
+													)
+													.some((f) => f.duckRequiresPassword === true);
 
 												if (requiresPassword) {
 													setDecodePassword("");
 													setShowDecodeDialog(true);
 												} else {
-													handleDecode();
+													handleDecode("");
 												}
 											}}
 											disabled={toolbarDisabled || !hasDuckEncodedImages}
@@ -1001,15 +1005,17 @@ export function MediaSelectionToolbar({
 												size="icon"
 												onClick={() => {
 													// Check if any duck-encoded file requires password
-									const requiresPassword = selectedFiles
-										.filter((f) => f.type === "image" && f.isDuckEncoded)
-										.some((f) => f.duckRequiresPassword !== false);
+													const requiresPassword = selectedFiles
+														.filter(
+															(f) => f.type === "image" && f.isDuckEncoded,
+														)
+														.some((f) => f.duckRequiresPassword === true);
 
 													if (requiresPassword) {
 														setDecodePassword("");
 														setShowDecodeDialog(true);
 													} else {
-														handleDecode();
+														handleDecode("");
 													}
 												}}
 												disabled={toolbarDisabled || !hasDuckEncodedImages}
@@ -1190,7 +1196,7 @@ export function MediaSelectionToolbar({
 								Cancel
 							</Button>
 							<Button
-								onClick={handleDecode}
+								onClick={() => handleDecode()}
 								disabled={isDecoding}
 								className="bg-green-600 hover:bg-green-700"
 							>


### PR DESCRIPTION
## Summary
- Fix workspace duck decode behavior so password dialog opens only when password is explicitly required.
- Replace default prompt gating from unknown-as-required to explicit duckRequiresPassword === true checks.
- Keep direct decode flow for non-protected duck images without showing password prompt.
- Add required plan/TODO docs for this change.

Closes #67

## Testing
- npm run build (runninghub-nextjs)
- Manual UI validation passed:
  - duck image without password decodes without showing dialog
  - password-protected duck image still shows password dialog

## Checklist
- [x] Docs updated (plan + todos)
- [x] Build passes
- [x] Behavior verified for both non-protected and protected duck images