### PR TITLE
fix(workspace): improve prompt menu and copy

### DIFF
--- a/runninghub-nextjs/docs/workspace-prompt-indicator-copy-fix-plan.md
+++ b/runninghub-nextjs/docs/workspace-prompt-indicator-copy-fix-plan.md
@@ -1,0 +1,24 @@
+# Workspace Prompt Indicator Copy Fix Plan
+
+## Overview
+Fix issue 69 for workspace media prompt metadata handling. Media items that already have prompt metadata need a visible context-menu indicator, and the prompt dialog copy action needs reliable clipboard behavior.
+
+## Current State
+- `MediaGallery` shows a generic `Prompt` context-menu item whenever the workspace page provides `onPrompt`.
+- Files with prompt metadata are not visually distinguished from files without prompt metadata in the context menu.
+- The workspace prompt dialog displays prompt content, but its copy button calls `navigator.clipboard.writeText` without awaiting success or handling fallback/error states.
+
+## Target State
+- The context-menu `Prompt` item clearly indicates when a file already has prompt metadata.
+- Prompt content still opens from the context menu for both images and videos.
+- The dialog copy button copies the currently displayed prompt content and reports success or failure accurately.
+
+## Technical Approach
+1. Add a small `hasPromptMetadata` check in `MediaGallery` based on `file.prompt`.
+2. Render a visible badge/icon state on the context-menu `Prompt` item when prompt metadata is known.
+3. Add a workspace page clipboard helper that awaits `navigator.clipboard.writeText`, falls back to a textarea copy for browsers where needed, and reports failures with `toast.error`.
+4. Reuse the helper from the prompt dialog copy button.
+
+## Validation
+- Build the frontend with `npm run build`.
+- Verify the changed context-menu markup and copy handler compile under strict TypeScript.

--- a/runninghub-nextjs/docs/workspace-prompt-indicator-copy-fix-todos.md
+++ b/runninghub-nextjs/docs/workspace-prompt-indicator-copy-fix-todos.md
@@ -1,0 +1,6 @@
+# Workspace Prompt Indicator Copy Fix TODOs
+
+- [x] Check existing prompt metadata and context-menu docs.
+- [x] Add visible prompt metadata indicator to the media context menu.
+- [x] Fix prompt dialog copy behavior with async clipboard handling and fallback.
+- [x] Run frontend build.

--- a/runninghub-nextjs/src/app/workspace/page.tsx
+++ b/runninghub-nextjs/src/app/workspace/page.tsx
@@ -293,6 +293,34 @@ export default function WorkspacePage() {
 		return value;
 	}, []);
 
+	const copyTextToClipboard = useCallback(async (text: string) => {
+		try {
+			if (navigator.clipboard?.writeText) {
+				await navigator.clipboard.writeText(text);
+				return true;
+			}
+		} catch (error) {
+			console.error("Clipboard API copy failed:", error);
+		}
+
+		try {
+			const textArea = document.createElement("textarea");
+			textArea.value = text;
+			textArea.setAttribute("readonly", "");
+			textArea.style.position = "fixed";
+			textArea.style.left = "-9999px";
+			textArea.style.top = "0";
+			document.body.appendChild(textArea);
+			textArea.select();
+			const copied = document.execCommand("copy");
+			document.body.removeChild(textArea);
+			return copied;
+		} catch (error) {
+			console.error("Fallback clipboard copy failed:", error);
+			return false;
+		}
+	}, []);
+
 	const fetchPromptMetadata = useCallback(
 		async (file: MediaFile, silent = true) => {
 			try {
@@ -3269,12 +3297,16 @@ export default function WorkspacePage() {
 									<Button
 										variant="outline"
 										size="sm"
-										onClick={() => {
+										onClick={async () => {
 											const content = isPromptFormatted
 												? formatPrompt(promptContent) || ""
 												: promptContent || "";
-											navigator.clipboard.writeText(content);
-											toast.success("Prompt copied to clipboard");
+											const copied = await copyTextToClipboard(content);
+											if (copied) {
+												toast.success("Prompt copied to clipboard");
+											} else {
+												toast.error("Failed to copy prompt");
+											}
 										}}
 										disabled={!promptContent}
 									>

--- a/runninghub-nextjs/src/components/workspace/MediaGallery.tsx
+++ b/runninghub-nextjs/src/components/workspace/MediaGallery.tsx
@@ -155,6 +155,10 @@ function formatPrompt(prompt?: string): string | null {
 	return prompt;
 }
 
+function hasPromptMetadata(file: MediaFile): boolean {
+	return typeof file.prompt === "string" && file.prompt.trim().length > 0;
+}
+
 export type MediaGalleryMode = "workspace" | "dataset";
 
 export interface MediaGalleryProps {
@@ -1105,9 +1109,21 @@ export function MediaGallery({
 																	e.stopPropagation();
 																	onPrompt(file);
 																}}
+																className={cn(
+																	hasPromptMetadata(file) &&
+																		"bg-blue-50/70 text-blue-700 focus:bg-blue-100 focus:text-blue-800",
+																)}
 															>
 																<MessageSquare className="h-4 w-4 mr-2" />
-																Prompt
+																<span className="flex-1">Prompt</span>
+																{hasPromptMetadata(file) && (
+																	<Badge
+																		variant="secondary"
+																		className="ml-3 h-5 bg-blue-100 px-1.5 text-[10px] font-medium text-blue-700"
+																	>
+																		Available
+																	</Badge>
+																)}
 															</DropdownMenuItem>
 														)}
 														{onDecode && file.isDuckEncoded && (


### PR DESCRIPTION
## Summary
- Add a visible prompt-available badge and highlight to the workspace media context menu when prompt metadata is known.
- Make the prompt metadata dialog copy button await clipboard writes, use a fallback copy path, and show accurate success/error feedback.
- Add required plan and TODO docs for the fix.

Fixes #69

## Testing
- [x] cd runninghub-nextjs && npm run build
- [x] git diff --check

## Checklist
- [x] Branch created from latest main
- [x] Required plan/TODO docs added
- [x] Frontend build passes