### PR TITLE
feat(workspace): add first-frame clip shortcut

### DIFF
--- a/runninghub-nextjs/docs/workspace-clip-first-frame-shortcut-plan.md
+++ b/runninghub-nextjs/docs/workspace-clip-first-frame-shortcut-plan.md
@@ -1,0 +1,33 @@
+# Workspace Clip First Frame Shortcut Plan
+
+## Overview
+Add a workspace shortcut that clips the first frame from selected video files without using the Video Clipping tab configuration.
+
+## Requirements
+- Use latest `main` and implement on a new feature branch.
+- Add the shortcut to video context menus.
+- Add the shortcut to the media selection toolbar.
+- Ignore existing clip configuration settings.
+- Support clipping multiple selected videos.
+
+## Current State
+- The workspace has a configurable video clip flow through `VideoClipConfiguration`.
+- `handleClipVideos` reads `useVideoClipStore`, so toolbar or clip-tab actions use the current clip settings.
+- `MediaGallery` has per-file context-menu actions but no first-frame shortcut.
+
+## Target State
+- Video context menus include a `Clip First Frame` action.
+- The workspace selection toolbar includes a `First Frame` action when selected media contains videos.
+- The new shortcut sends a fixed `first_frame` clip request for all selected videos.
+- Output is saved to the current workspace folder so users can refresh and see generated images.
+
+## Technical Approach
+1. Add a fixed first-frame clip config in the workspace page.
+2. Add a `handleClipFirstFrameVideos` handler that accepts multiple `MediaFile`s, filters videos, posts to `/api/videos/clip`, and sets the active console task.
+3. Add `onClipFirstFrame` props to `MediaSelectionToolbar` and `MediaGallery`.
+4. Render toolbar and context-menu controls only for video selections/files.
+5. Keep the existing configurable clip tab and generic clip action unchanged.
+
+## Validation
+- Run `npm run build` in `runninghub-nextjs`.
+- Confirm TypeScript compiles for new props and fixed config.

--- a/runninghub-nextjs/docs/workspace-clip-first-frame-shortcut-todos.md
+++ b/runninghub-nextjs/docs/workspace-clip-first-frame-shortcut-todos.md
@@ -1,0 +1,8 @@
+# Workspace Clip First Frame Shortcut TODOs
+
+- [x] Create feature branch from latest `main`.
+- [x] Add plan and TODO docs.
+- [x] Add fixed first-frame clip handler in the workspace page.
+- [x] Add toolbar shortcut for selected videos.
+- [x] Add video context-menu shortcut.
+- [x] Run frontend build.

--- a/runninghub-nextjs/src/app/workspace/page.tsx
+++ b/runninghub-nextjs/src/app/workspace/page.tsx
@@ -80,7 +80,7 @@ import {
 import { toast } from "sonner";
 import { logger } from "@/utils/logger";
 import { isDuckEncodedFilename } from "@/utils/duck";
-import { API_ENDPOINTS, ERROR_MESSAGES } from "@/constants";
+import { API_ENDPOINTS, CLIP_MODES, ERROR_MESSAGES } from "@/constants";
 import { cn } from "@/lib/utils";
 import {
 	exportImagesToFolder,
@@ -102,7 +102,20 @@ import type {
 	LocalWorkflow,
 	LocalWorkflowOperationType,
 } from "@/types/workspace";
+import type { VideoClipConfig } from "@/types/video-clip";
 import { mapLocalWorkflowToWorkflow } from "@/lib/local-workflow-mapper";
+
+const FIRST_FRAME_CLIP_CONFIG: VideoClipConfig = {
+	mode: CLIP_MODES.FIRST_FRAME,
+	imageFormat: "png",
+	quality: 95,
+	frameCount: 1,
+	intervalSeconds: 10,
+	intervalFrames: 1,
+	organizeByVideo: false,
+	deleteOriginal: false,
+	saveToWorkspace: true,
+};
 
 export default function WorkspacePage() {
 	// Folder store state - use page-specific folder state for workspace page
@@ -1963,6 +1976,44 @@ export default function WorkspacePage() {
 		handleClipVideos([video.path]);
 	}, []);
 
+	const handleClipFirstFrameVideos = useCallback(
+		async (files: MediaFile[]) => {
+			const videoFiles = files.filter((file) => file.type === "video");
+			if (videoFiles.length === 0) {
+				toast.error("No videos selected");
+				return;
+			}
+
+			try {
+				const response = await fetch(API_ENDPOINTS.VIDEOS_CLIP, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						videos: videoFiles.map((file) => file.path),
+						clip_config: FIRST_FRAME_CLIP_CONFIG,
+						timeout: 3600,
+						outputDir: selectedFolder?.folder_path,
+					}),
+				});
+
+				const data = await response.json();
+
+				if (data.success) {
+					setActiveConsoleTaskId(data.task_id);
+					toast.success(
+						`Started first-frame clipping for ${videoFiles.length} video${videoFiles.length > 1 ? "s" : ""}`,
+					);
+				} else {
+					toast.error(data.error || "Failed to start first-frame clipping");
+				}
+			} catch (error) {
+				console.error("Error clipping first frame:", error);
+				toast.error("Failed to start first-frame clipping");
+			}
+		},
+		[selectedFolder?.folder_path],
+	);
+
 	const handleVideoSelectionChange = useCallback(
 		(videoPath: string, selected: boolean) => {
 			updateMediaFile(videoPath, { selected });
@@ -2749,6 +2800,7 @@ export default function WorkspacePage() {
 									onBatchProcess={handleBatchProcess}
 									batchWorkflowId={selectedComplexWorkflowId}
 									batchWorkflowName={selectedComplexWorkflowName}
+									onClipFirstFrame={handleClipFirstFrameVideos}
 									onExport={handleExport}
 									onExportToDataset={() => {
 										setFileToExportToDataset(null); // null means use selectedFiles
@@ -2806,6 +2858,7 @@ export default function WorkspacePage() {
 										setShowResizeDialog(true);
 									}}
 									onPrompt={handleViewPromptForFile}
+									onClipFirstFrame={handleClipFirstFrameVideos}
 								/>
 							</TabsContent>
 

--- a/runninghub-nextjs/src/components/workspace/MediaGallery.tsx
+++ b/runninghub-nextjs/src/components/workspace/MediaGallery.tsx
@@ -174,6 +174,7 @@ export interface MediaGalleryProps {
 	onResize?: (file: MediaFile) => void;
 	onAddCaption?: (files: MediaFile[]) => Promise<void>;
 	onPrompt?: (file: MediaFile) => void;
+	onClipFirstFrame?: (files: MediaFile[]) => Promise<void>;
 	className?: string;
 }
 
@@ -190,6 +191,7 @@ export function MediaGallery({
 	onResize,
 	onAddCaption,
 	onPrompt,
+	onClipFirstFrame,
 	className = "",
 }: MediaGalleryProps) {
 	const {
@@ -1124,6 +1126,17 @@ export function MediaGallery({
 																		Available
 																	</Badge>
 																)}
+															</DropdownMenuItem>
+														)}
+														{onClipFirstFrame && file.type === "video" && (
+															<DropdownMenuItem
+																onClick={(e) => {
+																	e.stopPropagation();
+																	void onClipFirstFrame([file]);
+																}}
+															>
+																<FileImage className="h-4 w-4 mr-2 text-cyan-600" />
+																Clip First Frame
 															</DropdownMenuItem>
 														)}
 														{onDecode && file.isDuckEncoded && (

--- a/runninghub-nextjs/src/components/workspace/MediaSelectionToolbar.tsx
+++ b/runninghub-nextjs/src/components/workspace/MediaSelectionToolbar.tsx
@@ -10,6 +10,7 @@ import {
 	Eye,
 	AlertCircle,
 	Scissors,
+	FileImage,
 	Download,
 	Zap,
 	Maximize2,
@@ -79,6 +80,7 @@ interface MediaSelectionToolbarProps {
 	batchWorkflowId?: string | null;
 	batchWorkflowName?: string | null;
 	onClip?: (files: MediaFile[]) => Promise<void>;
+	onClipFirstFrame?: (files: MediaFile[]) => Promise<void>;
 	onExport?: (files: MediaFile[]) => Promise<void>;
 	onConvertFps?: (files: MediaFile[]) => Promise<void>;
 	onResize?: (
@@ -123,6 +125,7 @@ export function MediaSelectionToolbar({
 	batchWorkflowId = null,
 	batchWorkflowName = null,
 	onClip,
+	onClipFirstFrame,
 	onExport,
 	onConvertFps,
 	onResize,
@@ -137,6 +140,11 @@ export function MediaSelectionToolbar({
 	showCaptionButton = false,
 }: MediaSelectionToolbarProps) {
 	const selectedCount = selectedFiles.length;
+	const selectedVideoFiles = useMemo(
+		() => selectedFiles.filter((file) => file.type === "video"),
+		[selectedFiles],
+	);
+	const selectedVideoCount = selectedVideoFiles.length;
 
 	// Count duck-encoded images in selection
 	const duckEncodedCount = useMemo(() => {
@@ -174,6 +182,7 @@ export function MediaSelectionToolbar({
 	const [isDeleting, setIsDeleting] = useState(false);
 	const [isDecoding, setIsDecoding] = useState(false);
 	const [isClipping, setIsClipping] = useState(false);
+	const [isClippingFirstFrame, setIsClippingFirstFrame] = useState(false);
 	const [isBatchProcessing, setIsBatchProcessing] = useState(false);
 	const [isResizing, setIsResizing] = useState(false);
 	const [isCaptioning, setIsCaptioning] = useState(false);
@@ -394,8 +403,7 @@ export function MediaSelectionToolbar({
 
 		setIsClipping(true);
 		try {
-			const videoFiles = selectedFiles.filter((f) => f.type === "video");
-			await onClip(videoFiles);
+			await onClip(selectedVideoFiles);
 			onDeselectAll?.(); // Clear selection after action
 		} catch (error) {
 			toast.error(
@@ -404,7 +412,25 @@ export function MediaSelectionToolbar({
 		} finally {
 			setIsClipping(false);
 		}
-	}, [onClip, selectedFiles, onDeselectAll]);
+	}, [onClip, selectedVideoFiles, onDeselectAll]);
+
+	const handleClipFirstFrame = useCallback(async () => {
+		if (!onClipFirstFrame) return;
+
+		setIsClippingFirstFrame(true);
+		try {
+			await onClipFirstFrame(selectedVideoFiles);
+			onDeselectAll?.();
+		} catch (error) {
+			toast.error(
+				error instanceof Error
+					? error.message
+					: "Failed to clip first frame",
+			);
+		} finally {
+			setIsClippingFirstFrame(false);
+		}
+	}, [onClipFirstFrame, selectedVideoFiles, onDeselectAll]);
 
 	// Handle export
 	const handleExportClick = useCallback(() => {
@@ -517,6 +543,7 @@ export function MediaSelectionToolbar({
 		isDeleting ||
 		isDecoding ||
 		isClipping ||
+		isClippingFirstFrame ||
 		isResizing ||
 		isCaptioning;
 
@@ -533,6 +560,10 @@ export function MediaSelectionToolbar({
 
 	const selectedCountLabel =
 		selectedCount === 1 ? "1 selected" : `${selectedCount} selected`;
+	const selectedVideoCountLabel =
+		selectedVideoCount === 1
+			? "1 video selected"
+			: `${selectedVideoCount} videos selected`;
 
 	return (
 		<>
@@ -614,8 +645,7 @@ export function MediaSelectionToolbar({
 											size="icon"
 											onClick={handleClip}
 											disabled={
-												toolbarDisabled ||
-												!selectedFiles.some((f) => f.type === "video")
+												toolbarDisabled || selectedVideoCount === 0
 											}
 											className="h-11 w-20 bg-purple-600 hover:bg-purple-700"
 											aria-label="Clip videos"
@@ -624,6 +654,29 @@ export function MediaSelectionToolbar({
 												<Loader2 className="h-4 w-4 animate-spin" />
 											) : (
 												<Scissors className="h-4 w-4" />
+											)}
+										</Button>
+									</ToolbarTooltip>
+								)}
+
+								{onClipFirstFrame && (
+									<ToolbarTooltip
+										content={`First frame • ${selectedVideoCountLabel}`}
+									>
+										<Button
+											variant="default"
+											size="icon"
+											onClick={handleClipFirstFrame}
+											disabled={
+												toolbarDisabled || selectedVideoCount === 0
+											}
+											className="h-11 w-20 bg-cyan-600 hover:bg-cyan-700"
+											aria-label="Clip first frame"
+										>
+											{isClippingFirstFrame ? (
+												<Loader2 className="h-4 w-4 animate-spin" />
+											) : (
+												<FileImage className="h-4 w-4" />
 											)}
 										</Button>
 									</ToolbarTooltip>
@@ -847,8 +900,7 @@ export function MediaSelectionToolbar({
 											size="icon"
 											onClick={handleClip}
 											disabled={
-												toolbarDisabled ||
-												!selectedFiles.some((f) => f.type === "video")
+												toolbarDisabled || selectedVideoCount === 0
 											}
 											className="h-10 w-18 text-gray-300 hover:text-white hover:bg-gray-800 rounded-full"
 											aria-label="Clip videos"
@@ -857,6 +909,29 @@ export function MediaSelectionToolbar({
 												<Loader2 className="h-3.5 w-3.5 animate-spin" />
 											) : (
 												<Scissors className="h-3.5 w-3.5 text-purple-400" />
+											)}
+										</Button>
+									</ToolbarTooltip>
+								)}
+
+								{onClipFirstFrame && (
+									<ToolbarTooltip
+										content={`First frame • ${selectedVideoCountLabel}`}
+									>
+										<Button
+											variant="ghost"
+											size="icon"
+											onClick={handleClipFirstFrame}
+											disabled={
+												toolbarDisabled || selectedVideoCount === 0
+											}
+											className="h-10 w-18 text-gray-300 hover:text-white hover:bg-gray-800 rounded-full"
+											aria-label="Clip first frame"
+										>
+											{isClippingFirstFrame ? (
+												<Loader2 className="h-3.5 w-3.5 animate-spin" />
+											) : (
+												<FileImage className="h-3.5 w-3.5 text-cyan-400" />
 											)}
 										</Button>
 									</ToolbarTooltip>


### PR DESCRIPTION
## Summary
- Add a fixed first-frame clipping shortcut for workspace videos that ignores the existing clip configuration settings.
- Add the shortcut to the media selection toolbar and video context menu.
- Support clipping multiple selected videos in one request and route output to the current workspace folder.
- Add required plan and TODO docs.

Closes #71

## Testing
- [x] cd runninghub-nextjs && npm run build
- [x] git diff --check
- [x] Verified /workspace on port 3001 returned HTTP 200

## Checklist
- [x] Branch created from latest main
- [x] Context menu action added for videos
- [x] Toolbar action added for selected videos
- [x] Multiple selected videos supported
- [x] Existing configurable clip flow left unchanged